### PR TITLE
Use globally installed node for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
 - oraclejdk7
 script:
 - "./gradlew ci --stacktrace"
+sudo: false
 deploy:
   provider: releases
   api_key:

--- a/src/integTest/groovy/com/palantir/bowerdeps/BowerDepsPluginIntegSpec.groovy
+++ b/src/integTest/groovy/com/palantir/bowerdeps/BowerDepsPluginIntegSpec.groovy
@@ -31,10 +31,7 @@ class BowerDepsPluginIntegSpec extends IntegrationSpec {
 
         buildFile << """
             node {
-                version = '0.12.3'
-                npmVersion = '2.10.0'
-                download = true
-                workDir = file('build/node')
+                download = false
             }
         """.stripIndent()
     }
@@ -63,10 +60,9 @@ class BowerDepsPluginIntegSpec extends IntegrationSpec {
         }'''.stripIndent()
 
         when:
-        def result = runTasksSuccessfully('nodeSetup', 'build')
+        def result = runTasksSuccessfully('build')
 
         then:
-        result.wasExecuted('nodeSetup')
         result.wasUpToDate('build')
     }
 

--- a/src/integTest/groovy/com/palantir/bowerdeps/BowerDepsPluginMultiProjectIntegSpec.groovy
+++ b/src/integTest/groovy/com/palantir/bowerdeps/BowerDepsPluginMultiProjectIntegSpec.groovy
@@ -22,9 +22,6 @@ import com.moowork.gradle.grunt.GruntPlugin
 import com.moowork.gradle.gulp.GulpPlugin
 
 class BowerDepsPluginMultiProjectIntegSpec extends IntegrationSpec {
-    def nodeVersion = '0.12.3'
-    def npmVersion = '2.10.0'
-
     def 'no plugins and no build task specified'() {
         setup:
         // Root
@@ -33,10 +30,7 @@ class BowerDepsPluginMultiProjectIntegSpec extends IntegrationSpec {
 
         buildFile << """
         node {
-            version = '$nodeVersion'
-            npmVersion = '$npmVersion'
-            download = true
-            workDir = file('build/node')
+            download = false
         }
         """.stripIndent()
 
@@ -47,10 +41,8 @@ class BowerDepsPluginMultiProjectIntegSpec extends IntegrationSpec {
         ${applyPlugin(BowerDepsPlugin)}
 
         node {
-          nodeModulesDir = file('../')
-          npmVersion = '$npmVersion'
-          download = true
-          workDir = file('../build/node')
+            download = false
+            nodeModulesDir = file(rootDir)
         }
         """.stripIndent())
 
@@ -110,10 +102,7 @@ class BowerDepsPluginMultiProjectIntegSpec extends IntegrationSpec {
         ${applyPlugin(BowerDepsPlugin)}
 
         node {
-          nodeModulesDir = file('../')
-          npmVersion = '$npmVersion'
-          download = true
-          workDir = file('../build/node')
+            download = false
         }
 
         bowerdeps {
@@ -159,10 +148,8 @@ class BowerDepsPluginMultiProjectIntegSpec extends IntegrationSpec {
         ${applyPlugin(BowerDepsPlugin)}
 
         node {
-            nodeModulesDir = file('../')
-            npmVersion = '$npmVersion'
-            download = true
-            workDir = file('../build/node')
+            download = false
+            nodeModulesDir = file(rootDir)
         }
 
         grunt {
@@ -199,10 +186,9 @@ class BowerDepsPluginMultiProjectIntegSpec extends IntegrationSpec {
         }'''.stripIndent()
 
         when:
-        def result = runTasksSuccessfully('nodeSetup', 'installGrunt', 'installGulp', ':example-app:build')
+        def result = runTasksSuccessfully('installGrunt', 'installGulp', ':example-app:build')
 
         then:
-        result.wasExecuted('nodeSetup')
         result.wasExecuted(':example-lib-b:grunt_default')
         result.wasExecuted(':example-lib-a:grunt_watch')
         result.wasExecuted(':example-app:gulp_default')


### PR DESCRIPTION
This should resolve #1.

Integration tests should use the globally installed version of node
since the node plugin doesn't support installing correctly on all
platforms.

Travis CI will use whatever version of nodejs is on the build nodes.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/gradle-bowerdeps-plugin/2)

<!-- Reviewable:end -->
